### PR TITLE
Fix the locustfile and prevent future lint-related breakage.

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -1,0 +1,3 @@
+# Note: All imports in this file are used by Locust to locate tests.
+from circulation_load_test.cm.basic import CMTests  # noqa: autoflake
+from circulation_load_test.registry.registry import RegistryTests  # noqa: autoflake


### PR DESCRIPTION
## Description

This adds comments to ensure that imports are preserved in the `locustfile.py`. Without them, the linting tools treat the imports as unused and remove them.

## Motivation and Context

Locust uses imports to locate test files. The `locustfile.py` contains imports that the linting tools don't realize are actually used.

## How Has This Been Tested?

I ran the linting tools locally.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
