### PR TITLE
Add more tests and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ and [Circulation Manager](https://github.com/ThePalaceProject/circulation) insta
 run. For the CM, a list of users (along with their passwords) must also be specified. One user must be declared
 as _primary_, as some tests will use this user as the default user for various reasons.
 
+The configuration file also contains a list of library identifiers that must exist on the target CM. These
+are used by tests that want to try making requests to random libraries.
+
 ```json
 {
   "registry": {
@@ -65,7 +68,12 @@ as _primary_, as some tests will use this user as the default user for various r
       "user2": {
         "password": "abcd1234"
       }
-    }
+    },
+    "library_identifiers": [
+      "Library1",
+      "Library2",
+      "Library3"
+    ]
   }
 }
 ```

--- a/src/circulation_load_test/cm/basic.py
+++ b/src/circulation_load_test/cm/basic.py
@@ -1,3 +1,5 @@
+import random
+
 from locust import tag, task
 
 from circulation_load_test.common.cmfeedwalk import CMFeedWalk
@@ -13,12 +15,24 @@ class CMTests(CMHTTPUser):
     host = Configurations.get().circulation_manager.address
 
     @task
+    @tag("cm")
     @tag("login")
     def login(self):
         """Check how long it takes to log in to the target CM."""
         CMLogin.login(self)
 
     @task
+    @tag("cm")
+    @tag("login_multiple")
+    def login_multiple(self):
+        """Check how long it takes to log in to the target CM."""
+        id = random.choice(
+            list(Configurations.get().circulation_manager.library_identifiers)
+        )
+        CMLogin.login_specific(self, id)
+
+    @task
+    @tag("cm")
     @tag("feeds")
     def random_feed_walk(self):
         """Walk through feeds at random until reaching a maximum depth."""
@@ -32,6 +46,7 @@ class CMTests(CMHTTPUser):
         walk.execute(self)
 
     @task
+    @tag("cm")
     @tag("search")
     def random_search(self):
         """Perform a random search and walk through all the results."""
@@ -42,6 +57,7 @@ class CMTests(CMHTTPUser):
         search.execute(self)
 
     @task
+    @tag("cm")
     @tag("bookmarks")
     def bookmarks(self):
         """Borrow an open access book, and start producing a lot of bookmarks."""

--- a/src/circulation_load_test/common/config.py
+++ b/src/circulation_load_test/common/config.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 
 class CMUser:
@@ -50,13 +50,17 @@ class RConfiguration:
 class CMConfiguration:
     address: str
     users: Dict[str, CMUser]
+    library_identifiers: Set[str]
 
-    def __init__(self, address: str, users: Dict[str, CMUser]):
+    def __init__(
+        self, address: str, users: Dict[str, CMUser], library_identifiers: Set[str]
+    ):
         super().__init__()
         assert isinstance(address, str)
         assert isinstance(users, dict)
         self.address = address
         self.users = users
+        self.library_identifiers = library_identifiers
 
     def user_primary(self) -> CMUser:
         for name in self.users.keys():
@@ -68,6 +72,9 @@ class CMConfiguration:
     @staticmethod
     def parse(data: Any) -> "CMConfiguration":
         address = data["host"]
+
+        library_ids_in = data["library_identifiers"]
+        library_ids = set(library_ids_in)
 
         users_primary = False
         users_in = data["users"]
@@ -84,7 +91,7 @@ class CMConfiguration:
         if not users_primary:
             raise ValueError("Exactly one primary user must be defined!")
 
-        return CMConfiguration(address, users)
+        return CMConfiguration(address, users, library_ids)
 
 
 class Configuration:

--- a/tests/hosts.json
+++ b/tests/hosts.json
@@ -16,6 +16,10 @@
       "user2": {
         "password": "abcd1234"
       }
-    }
+    },
+    "library_identifiers": [
+      "HAZELNUT",
+      "WALNUT"
+    ]
   }
 }

--- a/tests/hosts_user_bad_0.json
+++ b/tests/hosts_user_bad_0.json
@@ -10,6 +10,10 @@
         "primary": "true",
         "password": "abcd1234"
       }
-    }
+    },
+    "library_identifiers": [
+      "HAZELNUT",
+      "WALNUT"
+    ]
   }
 }

--- a/tests/hosts_user_bad_1.json
+++ b/tests/hosts_user_bad_1.json
@@ -8,6 +8,10 @@
       "user1": {
         "password": "abcd1234"
       }
-    }
+    },
+    "library_identifiers": [
+      "HAZELNUT",
+      "WALNUT"
+    ]
   }
 }

--- a/tests/test_configurations.py
+++ b/tests/test_configurations.py
@@ -36,6 +36,7 @@ class TestConfigurations:
         config = configurations_fixture.load(file)
         assert "http://example1.example.com/" == config.circulation_manager.address
         assert 3 == len(config.circulation_manager.users)
+        assert {"HAZELNUT", "WALNUT"} == config.circulation_manager.library_identifiers
 
     def test_load_bad_user_0(self, configurations_fixture: ConfigurationsFixture):
         file = os.path.join(Path(__file__).parent, "hosts_user_bad_0.json")


### PR DESCRIPTION
## Description

This adds some new tests that can make requests to random libraries. It also adds more tags to the existing tests to allow for more filtering on the command-line.

## Motivation and Context

These are changes related to the ongoing SQL profiling work.

## How Has This Been Tested?

I ran the tests locally against a CM with 10 libraries, each with 10 collections.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
